### PR TITLE
Split out S3 client into its own module and misc code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 .venv
+src/*.save
+src/bin/*.save

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "dlio_s3_rust"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dlio_s3_rust"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 
 [lib]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 // src/lib.rs
+//
 // Copyright, 2025.  Signal65 / Futurum Group.
 //
 // Crate root — public re‑exports plus the Python module glue.
@@ -6,6 +7,8 @@
 #[cfg(feature = "extension-module")]
 use pyo3::prelude::*;
 
+// Local files to use
+pub mod s3_client;
 pub mod s3_utils;
 pub mod data_gen;
 

--- a/src/prefetch.rs
+++ b/src/prefetch.rs
@@ -1,11 +1,13 @@
-use crate::s3_utils::{get_object, parse_s3_uri};
 //
 // Copyright, 2025.  Signal65 / Futurum Group.
 // 
+
 use anyhow::{Context, Result};
 use futures::{stream::FuturesUnordered, StreamExt};
 use std::sync::Arc;
 use tokio::{sync::{mpsc, Semaphore}, task::JoinHandle};
+
+use crate::s3_utils::{get_object, parse_s3_uri};
 
 /// Item type returned to the consumer.
 pub type ObjectData = (String, Vec<u8>);

--- a/src/python_api.rs
+++ b/src/python_api.rs
@@ -1,7 +1,7 @@
+// src/python_api.rs
 //
 // Copyright, 2025.  Signal65 / Futurum Group.
 // 
-// src/python_api.rs
 //! PyO3 bindings — sync *and* async wrappers around the Rust S3 helpers.
 //!
 //! * **Sync** paths call `py.allow_threads` so the GIL is released while Rust blocks.

--- a/src/s3_client.rs
+++ b/src/s3_client.rs
@@ -1,0 +1,71 @@
+// src/s3_client.rs
+// 
+// Copyright, 2025.  Signal65 / Futurum Group.
+//
+//! Thread‑safe, blocking wrapper around the async AWS Rust SDK.
+//! Provides only the S3 client creation code 
+//!
+
+use anyhow::{bail, Result};
+use aws_config::meta::region::RegionProviderChain;
+use aws_sdk_s3::{config::Region, Client};
+use once_cell::sync::OnceCell;
+use std::env;
+use tokio::{runtime::Handle, task};
+
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+pub const DEFAULT_REGION: &str     = "us-east-1";
+
+
+// -----------------------------------------------------------------------------
+// Global S3 client (lazy, thread‑safe)
+// -----------------------------------------------------------------------------
+static CLIENT: OnceCell<Client> = OnceCell::new();
+static RUNTIME: OnceCell<tokio::runtime::Runtime> = OnceCell::new();   // for block_on fallback
+
+pub fn aws_s3_client() -> Result<Client> {
+    CLIENT.get_or_try_init(|| {
+        dotenvy::dotenv().ok();
+        if env::var("AWS_ACCESS_KEY_ID").is_err() || env::var("AWS_SECRET_ACCESS_KEY").is_err() {
+            bail!("Missing AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY");
+        }
+        let region = RegionProviderChain::first_try(env::var("AWS_REGION").ok().map(Region::new))
+            .or_default_provider()
+            .or_else(Region::new(DEFAULT_REGION));
+        let mut loader = aws_config::defaults(aws_config::BehaviorVersion::latest()).region(region);
+        if let Ok(endpoint) = env::var("AWS_ENDPOINT_URL") {
+            if !endpoint.is_empty() {
+                loader = loader.endpoint_url(endpoint);
+            }
+        }
+        let fut = loader.load();
+        let cfg = match Handle::try_current() {
+            Ok(handle) => task::block_in_place(|| handle.block_on(fut)),
+            Err(_) => {
+                let rt = RUNTIME.get_or_init(|| {
+                    tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime")
+                });
+                rt.block_on(fut)
+            }
+        };
+        Ok::<_, anyhow::Error>(Client::new(&cfg))
+    }).map(Clone::clone)
+}
+
+// -----------------------------------------------------------------------------
+// Helper: synchronously wait on a future
+// -----------------------------------------------------------------------------
+pub fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+    if let Ok(handle) = Handle::try_current() {
+        handle.block_on(fut)
+    } else {
+        let rt = RUNTIME.get_or_init(|| {
+            tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime")
+        });
+        rt.block_on(fut)
+    }
+}
+


### PR DESCRIPTION
I split out the S3 code into two files / modules.  One just for client creation, the other that has all the S3 code that uses the client.  This should help for the next step where we need to modify / fix the s3 client creation to enable use of TLS, with custom certs, etc.  